### PR TITLE
Release a statically compiled binary for Linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,11 +46,11 @@ jobs:
       matrix:
         goos: [linux, darwin, windows]
         goarch: [amd64]
+    container:
+      image: docker.io/library/golang:1.16.5-alpine3.14
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.16
+      - name: Install tooling to compile go binary
+        run: apk --no-cache add git gcc musl-dev
       - name: Checkout code
         uses: actions/checkout@v2
         with:
@@ -67,7 +67,13 @@ jobs:
           fi
       - name: Build
         id: build
-        run: go build -o bin/${{ steps.artifact.outputs.name }} -ldflags="-X 'main.Version=${{ needs.release.outputs.version }}'"
+        run: |
+          if [[ ${{ matrix.goos }} = linux ]]; then
+            go build -o bin/${{ steps.artifact.outputs.name }} -a -tags netgo \
+              -ldflags='-s -w -extldflags "-static" -X "main.Version=${{ needs.release.outputs.version }}"' .
+          else
+            go build -o bin/${{ steps.artifact.outputs.name }} -ldflags="-X 'main.Version=${{ needs.release.outputs.version }}'" .
+          fi
         env:
           GOARCH: ${{ matrix.goarch }}
           GOOS: ${{ matrix.goos }}


### PR DESCRIPTION
The release.yml workflow will now compile a static and stripped binary
for Linux.