### PR TITLE
Install bash in alpine release container

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,8 @@ jobs:
       image: docker.io/library/golang:1.16.5-alpine3.14
     steps:
       - name: Install tooling to compile go binary
-        run: apk --no-cache add git gcc musl-dev
+        run: apk --no-cache add git gcc musl-dev bash
+        shell: sh
       - name: Checkout code
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Because the default shell is set to bash, run steps are not able to run.
By specifying "sh" to be the shell for the first step, and installing
bash in this step, the following steps should work as intended.