### PR TITLE
fix: configuration should always be optional

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -14,6 +14,7 @@ rules:
       - perf
       - test
       - revert
+  body-max-line-length: 500
 help: |
   **Possible types**:
   `chore`:    Change build process, tooling or dependencies.

--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -14,7 +14,7 @@ rules:
       - perf
       - test
       - revert
-  body-max-line-length: 500
+  body-max-line-length: [1, 'always', 500]
 help: |
   **Possible types**:
   `chore`:    Change build process, tooling or dependencies.

--- a/util/config_test.go
+++ b/util/config_test.go
@@ -1,0 +1,29 @@
+package util
+
+import (
+	"github.com/Flaque/filet"
+	"github.com/stretchr/testify/suite"
+	"os"
+	"testing"
+)
+
+type ConfigTestSuite struct {
+	suite.Suite
+}
+
+func (suite *ConfigTestSuite) SetupSuite() {
+}
+
+func (suite *ConfigTestSuite) TestInitializeConfig_NoConfig() {
+	os.Setenv("HOME", filet.TmpDir(suite.T(), ""))
+	InitializeConfig()
+	//r := suite.Require()
+}
+
+func (suite *ConfigTestSuite) TearDownSuite() {
+	filet.CleanUp(suite.T())
+}
+
+func TestConfigTestSuite(t *testing.T) {
+	suite.Run(t, new(ConfigTestSuite))
+}


### PR DESCRIPTION
Configuration of gosh is only needed for a handful of command (sometimes even only with specific flags) so config should be completely optional

Viper returns a viper.ConfigFileNotFoundError when it cannot find the config, but when the directory also does not exist, it returns a fs.PathError instead, so I added a check on existence of the config file before reading it with viper

Fixes #19