### PR TITLE
feat: support basic and ssh auth for GIT operations

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,61 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var (
+	configCmd = &cobra.Command{
+		Use:   "config",
+		Short: "Displays information about configuration options for Gosh",
+		Long: `Configuration options:
+1) ~/.gosh/config.yml or ./.gosh/config.yml
+
+You can configure different ways to authenticate for GIT operations
+NOTE: only use one of these in your actual config
+
+1.1) Basic Auth
+Auth:
+  Type: Basic
+  User: your-user
+  Pass: your-pass-base64-encoded
+
+IMPORTANT: Use HTTPS URLs for your GIT repository URLs when using basic auth!
+
+1.2) SSH Key
+Auth:
+  Type: ssh
+  Private_Key_File: ~/.ssh/id_rsa
+  Private_Key_Pass: your-private-key-pass-base64-encoded
+
+If you want to use Gosh artifacts and replacements, you also have to configure these
+
+ArtifactRepositories:
+  maven:
+    default: https://your.maven.repo/repository/tm-released
+    STAGE_NAME: https://your.maven.repo/repository/tm-tested
+    OTHER_STAGE: https://your.maven.repo/repository/tm-published
+  docker:
+    default: "your.docker.registry"
+  ...
+
+You can add as many as you want/need
+
+2) Using ENV variables
+You can also configure authentication using ENV variables
+
+2.1) Basic Auth
+GOSH_AUTH_TYPE=basic
+GOSH_AUTH_USER=username
+GOSH_AUTH_PASS=your-pass-base64-encoded
+
+2.2) SSH
+GOSH_AUTH_TYPE=ssh
+GOSH_AUTH_PRIVATE_KEY_FILE=~/.ssh/id_rsa
+GOSH_AUTH_PRIVATE_KEY_PASS=your-private-key-pass-base64-encoded
+
+`,
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(configCmd)
+}

--- a/gitops/test_utils.go
+++ b/gitops/test_utils.go
@@ -57,10 +57,6 @@ func init() {
 	appContentsTemplate, _ = template.New("app").Parse(testAppFileContents)
 	releaseContentsTemplate, _ = template.New("release").Parse(testReleaseFileContents)
 	testConfig = &util.GoshConfig{
-		DeploymentRepository: util.DeploymentRepository{
-			SshKey:            "",
-			SshPrivateKeyPass: "",
-		},
 		ArtifactRepositories: nil,
 	}
 }

--- a/util/config_test.go
+++ b/util/config_test.go
@@ -4,20 +4,98 @@ import (
 	"github.com/Flaque/filet"
 	"github.com/stretchr/testify/suite"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
 type ConfigTestSuite struct {
 	suite.Suite
+	homedir string
+	workdir string
 }
 
 func (suite *ConfigTestSuite) SetupSuite() {
 }
 
+func (suite *ConfigTestSuite) SetupTest() {
+	os.Clearenv()
+	suite.homedir = filet.TmpDir(suite.T(), "")
+	suite.workdir = filet.TmpDir(suite.T(), "")
+	_ = os.Setenv("HOME", suite.homedir)
+	_ = os.Setenv("GOSH_WORKING_DIR", suite.workdir)
+	goshDir := filepath.Join(suite.homedir, ".gosh")
+	_ = os.MkdirAll(goshDir, 0755)
+}
+
 func (suite *ConfigTestSuite) TestInitializeConfig_NoConfig() {
-	os.Setenv("HOME", filet.TmpDir(suite.T(), ""))
 	InitializeConfig()
 	//r := suite.Require()
+}
+
+func (suite *ConfigTestSuite) TestInitializeConfig_BasicAuth_ConfigFile() {
+	contents := []byte(`
+Auth:
+  Type: basic
+  User: user1
+  Pass: my-pass
+`)
+	r := suite.Require()
+	err := os.WriteFile(filepath.Join(suite.homedir, ".gosh", "config.yml"), contents, 0644)
+	if err != nil {
+		r.Fail("unable to init test, cannot create ~/.gosh/config.yml file")
+	}
+	InitializeConfig()
+
+	r.Equal(BasicAuth, Config.Auth.Type())
+	auth := Config.Auth.(BasicAuthConfig)
+	r.Equal("user1", auth.User)
+	r.Equal("my-pass", auth.Pass)
+}
+
+func (suite *ConfigTestSuite) TestInitializeConfig_BasicAuth_Env() {
+	_ = os.Setenv("GOSH_AUTH_TYPE", "basic")
+	_ = os.Setenv("GOSH_AUTH_USER", "user1")
+	_ = os.Setenv("GOSH_AUTH_PASS", "my-pass")
+
+	InitializeConfig()
+	r := suite.Require()
+	r.Equal(BasicAuth, Config.Auth.Type())
+	auth := Config.Auth.(BasicAuthConfig)
+	r.Equal("user1", auth.User)
+	r.Equal("my-pass", auth.Pass)
+}
+
+func (suite *ConfigTestSuite) TestInitializeConfig_SshAuth_ConfigFile() {
+	contents := []byte(`
+Auth:
+  Type: ssh
+  Private_Key_File: private-key-file
+  Private_Key_Pass: private-key-pass
+`)
+	r := suite.Require()
+	err := os.WriteFile(filepath.Join(suite.homedir, ".gosh", "config.yml"), contents, 0644)
+	if err != nil {
+		r.Fail("unable to init test, cannot create ~/.gosh/config.yml file")
+	}
+	InitializeConfig()
+
+	r.Equal(SshKey, Config.Auth.Type())
+	auth := Config.Auth.(SshAuthConfig)
+	r.Equal("private-key-file", auth.PrivateKeyFile)
+	r.Equal("private-key-pass", auth.PrivateKeyPass)
+}
+
+func (suite *ConfigTestSuite) TestInitializeConfig_SshAuth_Env() {
+	_ = os.Setenv("GOSH_AUTH_TYPE", "ssh")
+	_ = os.Setenv("GOSH_AUTH_PRIVATE_KEY_FILE", "private-key-file")
+	_ = os.Setenv("GOSH_AUTH_PRIVATE_KEY_PASS", "private-key-pass")
+
+	InitializeConfig()
+	r := suite.Require()
+	r.Equal(SshKey, Config.Auth.Type())
+	auth := Config.Auth.(SshAuthConfig)
+	r.Equal("private-key-file", auth.PrivateKeyFile)
+	r.Equal("private-key-pass", auth.PrivateKeyPass)
 }
 
 func (suite *ConfigTestSuite) TearDownSuite() {

--- a/util/context.go
+++ b/util/context.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"errors"
 	"gosh/log"
 	"os"
 )
@@ -15,7 +16,18 @@ var Context = &GoshContext{}
 func init() {
 	Context.WorkingDir, _ = os.Getwd()
 	if wd, exists := os.LookupEnv("GOSH_WORKING_DIR"); exists {
-		log.Debugf("Setting working dir from ENV: %s", os.ExpandEnv(wd))
 		Context.WorkingDir = os.ExpandEnv(wd)
+		log.Debugf("Setting working dir from ENV: %s", Context.WorkingDir)
+	}
+	if wd, exists := os.LookupEnv("GOSH_WORK_DIR"); exists {
+		Context.WorkingDir = os.ExpandEnv(wd)
+		log.Debugf("Setting working dir from ENV: %s", Context.WorkingDir)
+	}
+	if _, err := os.Stat(Context.WorkingDir); err != nil {
+		if _, ok := err.(*os.PathError); ok {
+			if err = os.MkdirAll(Context.WorkingDir, 0755); err != nil {
+				log.Fatal(errors.New("working Directory does not exist"), "Working directory does not exist")
+			}
+		}
 	}
 }


### PR DESCRIPTION
You can now use both basic auth (e.g. GitHub Tokens or username/password) with HTTP based GIT repo access next to SSH based auth

Changed the structure of auth config and added full support for ENV vars

Added a new command `gosh config` to display config help