### PR TITLE
fix: TM release import fails

### DIFF
--- a/gitops/stage.go
+++ b/gitops/stage.go
@@ -26,7 +26,7 @@ func (stage *Stage) setInitialized() {
 }
 
 func NewStage(name string) *Stage {
-	return &Stage{Name: name, Versions: map[string]string{}}
+	return &Stage{Name: strings.ToLower(name), Versions: map[string]string{}}
 }
 
 func (stage *Stage) UpdateVersion(appName string, version string) error {

--- a/import/tm_import.go
+++ b/import/tm_import.go
@@ -39,7 +39,7 @@ var TrendMinerPlugin = &TmImportPlugin{}
 
 func importVersions() error {
 	log.Info("Starting import of versions")
-	stages := map[string]string{"TESTED": "alpha", "PUBLISHED": "stable", "RELEASED": "released"}
+	stages := map[string]string{"TESTED": "tested", "PUBLISHED": "published", "RELEASED": "released"}
 	for oldStage, stageName := range stages {
 		stage := gitops.NewStage(stageName)
 		if !stage.Exists() {
@@ -93,7 +93,11 @@ func importReleases() error {
 				filtered := filterSlice(releases, year)
 				for _, v := range filtered {
 					sort.Strings(v)
-					recentReleases = append(recentReleases, v[len(v)-2:]...)
+					if len(v) > 2 {
+						recentReleases = append(recentReleases, v[len(v)-2:]...)
+					} else {
+						recentReleases = append(recentReleases, v...)
+					}
 				}
 			}
 			sort.Strings(recentReleases)


### PR DESCRIPTION
When a year has less than 2 releases, import fails on illegal array index